### PR TITLE
Add parameter to skip puffs with low wind speeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,5 +73,14 @@ $ make all install
 ```
 It is advisable to install the library in the conda environment so that the python bindings are available. The environment variable $CONDA_PREFIX is set to the root of the conda environment.
 
-### Other notes
-- To run the tests you'll need the input data. It is currently stored on dropbox under fastGaussianPuff/test_data.
+## Danger zone
+This section contains details on special parameters that may cause erroneous output and have specific use-cases. When in doubt, re-run the model with default parameters and compare.
+
+`skip_low_wind` (bool), `low_wind_cutoff` (float, [m/s])
+- When true, skip_low_wind will cause the simulation to skip emitting puffs when the wind speed is below the low_wind_cutoff. This was added for convenience since the model is unreliable in low wind speeds (< 0.5m/s) and doesn't run if there is a wind speed of 0 m/s. 
+
+`exp_thresh_tolerance` (float. [ppm])
+- The tolerance for the thresholding algorithm. The model will skip evaluation of any cell that will produce a result less than this. Note that this is not one-to-one with the smallest concentration you'll see in the output due to how output data is resampled in time. As such, this should be set conservatively. Default: 1e-7
+
+`unsafe` (bool)
+- Turning this to true enables unsafe math operations that approximate evaluation of expensive functions and uses a tighter threshold. Expect to see between a 1.5-2x speed up, but the output may vary from what is expected. When in doubt, rerun the model with this off and compare.

--- a/src/GaussianPuff.py
+++ b/src/GaussianPuff.py
@@ -18,6 +18,7 @@ class GaussianPuff:
                  grid_coordinates=None,
                  nx=None, ny=None, nz=None,
                  puff_duration = 1200,
+                 skip_low_wind = False, low_wind_cutoff = -1,
                  exp_threshold_tolerance = None,
                  conversion_factor = 1e6*1.524,
                  unsafe=False, quiet=True):
@@ -67,6 +68,10 @@ class GaussianPuff:
                 for the puff stops when the plume has moved far away. In low wind speeds, however, this cutoff will
                 halt the simulation of a puff early. This may be desirable as exceedingly long (and likely unphysical)
                 plume departure times can be computed for wind speeds << 1 m/s
+            skip_low_wind (boolean), low_wind_cutoff [m/s] (float):
+                if True, the simulation will skip any time step where the wind speed is below low_wind_cutoff.
+                This is useful to avoid zero-values or situations where the wind is so slow that it'd create unreasonable predictions.
+                Default is False.
             exp_threshold_tolerance (scalar, float):
                 the tolerance used to threshold the exponentials when evaluating the Gaussian equation.
                 If, for example, exp_tol = 1e-9, the concentration at a single point for an individual time step
@@ -104,6 +109,13 @@ class GaussianPuff:
                 self.exp_threshold_tolerance = 1e-7
         else:
             self.exp_threshold_tolerance = exp_threshold_tolerance
+
+        if(skip_low_wind):
+            if(low_wind_cutoff <= 0):
+                print("[fGP] Error: low wind cutoff must be greater than 0")
+                exit(-1)
+            self.skip_low_wind = True
+            self.low_wind_cutoff = low_wind_cutoff
 
         ns = (simulation_end-simulation_start).total_seconds()
         self.n_obs = floor(ns/obs_dt) + 1 # number of observed data points we have
@@ -159,6 +171,7 @@ class GaussianPuff:
                     self.wind_speeds_sim, self.wind_directions_sim,
                     source_coordinates, emission_rates,
                     conversion_factor, self.exp_threshold_tolerance,
+                    skip_low_wind, low_wind_cutoff,
                     unsafe, quiet)
         else:
             self.using_sensors = True
@@ -178,6 +191,7 @@ class GaussianPuff:
                 self.wind_speeds_sim, self.wind_directions_sim,
                 source_coordinates, emission_rates,
                 conversion_factor, self.exp_threshold_tolerance,
+                skip_low_wind, low_wind_cutoff,
                 unsafe, quiet
             )
 

--- a/src/GaussianPuff.py
+++ b/src/GaussianPuff.py
@@ -112,8 +112,7 @@ class GaussianPuff:
 
         if(skip_low_wind):
             if(low_wind_cutoff <= 0):
-                print("[fGP] Error: low wind cutoff must be greater than 0")
-                exit(-1)
+                raise ValueError("[FastGaussianPuff] low wind cutoff must be greater than 0")
             self.skip_low_wind = True
             self.low_wind_cutoff = low_wind_cutoff
 
@@ -124,7 +123,7 @@ class GaussianPuff:
                                      emission_rates, grid_coordinates, sensor_coordinates)
         wind_speeds, wind_directions, source_coordinates, emission_rates, grid_coordinates, sensor_coordinates = arrays
 
-        self._check_wind_data(wind_speeds)
+        self._check_wind_data(wind_speeds, skip_low_wind)
 
         # resample the wind data from obs_dt to the simulation resolution sim_dt
         self._interpolate_wind_data(wind_speeds, wind_directions, puff_dt, simulation_start, simulation_end)
@@ -257,10 +256,12 @@ class GaussianPuff:
                 casted_arrays["sensor_coordinates"])
 
 
-    def _check_wind_data(self, ws):
+    def _check_wind_data(self, ws, skip_low_wind):
+        if skip_low_wind:
+            return
+        
         if np.any(ws <= 0):
-            print("[FastGaussianPuff] ERROR: wind speed <= 0 in the input. Exiting.")
-            exit(-1)
+            raise( ValueError("[FastGaussianPuff] wind speeds must be greater than 0"))
         if np.any(ws < 1e-2):
             print("[FastGaussianPuff] WARNING: There's a wind speed < 0.01 m/s. This is likely a mistake and will cause slow performance. The simulation will continue, but results will be poor as the puff model is degenerate in low wind speeds.")
 

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -26,11 +26,12 @@ def test_list_init():
 
 def test_bad_list_init():
     ws = [3]*61
-    wd = [200]*61
 
-    params["wind_speeds"] = pd.DataFrame(ws)
+    test_params = params.copy()
+
+    test_params["wind_speeds"] = pd.DataFrame(ws)
 
     with pytest.raises(TypeError):
-        gp = GP(**params, **grid_params)
+        gp = GP(**test_params, **grid_params)
     with pytest.raises(TypeError):
-        sp = GP(**params, **sensor_params)
+        sp = GP(**test_params, **sensor_params)

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -28,7 +28,6 @@ def test_bad_list_init():
     ws = [3]*61
     wd = [200]*61
 
-    # this should still work if we pass lists instead of numpy arrays
     params["wind_speeds"] = pd.DataFrame(ws)
 
     with pytest.raises(TypeError):

--- a/tests/test_special_params.py
+++ b/tests/test_special_params.py
@@ -20,3 +20,12 @@ def test_wind_skip():
 
     assert np.all(ch4_zero == 0)
     assert not np.all(ch4_nonzero == 0)
+
+def test_zero_wind():
+    ws = np.array([0.5]*61)
+    ws[20] = 0
+    params["wind_speeds"] = ws
+    params["skip_low_wind"] = False
+    # params["low_wind_cutoff"] = 0.1
+    with pytest.raises(ValueError, match="[FastGaussianPuff]*"):
+        gp = GP(**params, **grid_params)

--- a/tests/test_special_params.py
+++ b/tests/test_special_params.py
@@ -1,0 +1,22 @@
+import pytest
+import numpy as np
+import pandas as pd
+from utils import params, grid_params, sensor_params
+from FastGaussianPuff import GaussianPuff as GP
+
+def test_wind_skip():
+
+    gp = GP(**params, **grid_params)
+    gp.simulate()
+    ch4_nonzero = gp.ch4_obs.reshape((gp.n_out, *gp.grid_dims))
+
+    ws = np.array([0.2]*61)
+    params["wind_speeds"] = ws
+    params["skip_low_wind"] = True
+    params["low_wind_cutoff"] = 0.5
+    gp = GP(**params, **grid_params)
+    gp.simulate()
+    ch4_zero = gp.ch4_obs.reshape((gp.n_out, *gp.grid_dims))
+
+    assert np.all(ch4_zero == 0)
+    assert not np.all(ch4_nonzero == 0)


### PR DESCRIPTION
This adds an optional parameter that enables a simulation to run with zeros in the wind speeds. The model is degenerate in with a wind speed of 0 m/s, and the code breaks. People in the group wanted to be able to run the model on a year's worth of data without excessively cleaning it. This allows that to happen by skipping emission of puffs when the wind speed us below a user-specified cutoff. 

Note that this parameter is somewhat dangerous and could give bad outputs if used incorrectly. Default is for this mode to be off. 