### PR TITLE
More flexible support of source coordinate array format

### DIFF
--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -35,3 +35,26 @@ def test_bad_list_init():
         gp = GP(**test_params, **grid_params)
     with pytest.raises(TypeError):
         sp = GP(**test_params, **sensor_params)
+
+
+def test_source_coordinate_formats():
+    test_params = params.copy()
+
+    # test with a single source coordinate
+    test_params["source_coordinates"] = [[25, 25, 5]]
+    gp = GP(**test_params, **grid_params)
+    gp.simulate()
+    ans = np.linalg.norm(gp.ch4_obs)
+    assert ans > 0
+    # print(np.linalg.norm(gp.ch4_obs))
+
+    # test with a single source coordinate as a list
+    test_params["source_coordinates"] = [25, 25, 5]
+    gp = GP(**test_params, **grid_params)
+    gp.simulate()
+    assert np.linalg.norm(gp.ch4_obs) == ans
+
+    # test with multiple source coordinates
+    test_params["source_coordinates"] = [[25, 25, 5], [30, 30, 5]]
+    with pytest.raises(NotImplementedError):
+        gp = GP(**test_params, **grid_params)


### PR DESCRIPTION
This fixes an issue where inputting an array of the (reasonable) format [x0,y0,z0] for the source coordinates would cause incorrect output. The code now supports the formats [x0,y0,z0] and [[x0,y0,z0]]. The second format is kept in there so the code can be extended for multi-source support in the future. 

Closes #15 