### PR TITLE
Small linux build fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,8 +38,6 @@ class CMakeBuild(build_ext):
         # Set CXX compiler based on platform. This assumes that the compiler comes from cxx-compiler on conda-forge
         if sys.platform.startswith("darwin"):
             os.environ["CXX"] = os.environ["CONDA_PREFIX"] +  "/bin/clang++"
-        elif sys.platform.startswith("linux"):
-            os.environ["CXX"] = os.environ["CONDA_PREFIX"] +  "/bin/g++"
 
         build_args = ["--config", "Release"]
 


### PR DESCRIPTION
In the setup.py I was setting the compiler manually depending on the platform. This is a somewhat bad way of doing it, but it was done as a workaround to find the right C++ compiler for Macs. I'm leaving the Mac fix in there for now since I don't know of a better way of doing it, but removing the Linux one since it should work without it. 

This type of thing should probably get migrated to CMake in the end but this should work for now. 